### PR TITLE
Add tetromino rotate mechanics

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -1,54 +1,54 @@
 class Game
-  attr_reader :tetrominos, :color_map, :size
-  attr_accessor :gameboard, :tetromino
+    attr_reader :tetrominos, :color_map, :size
+    attr_accessor :gameboard, :tetromino
 
-  def initialize
-    # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
-    @tetrominos = [
-      Matrix[[1, 1, 1, 1]],
-      Matrix[[6, 0, 0], [6, 6, 6]],
-      Matrix[[0, 0, 7], [7, 7, 7]],
-      Matrix[[2, 2], [2, 2]],
-      Matrix[[0, 4, 4], [4, 4, 0]],
-      Matrix[[0, 3, 0], [3, 3, 3]],
-      Matrix[[5, 5, 0], [0, 5, 5]]
-    ]
-    
-    @color_map = {
-      1=>"aqua",
-      2=>"yellow",
-      3=>"purple",
-      4=>"green",
-      5=>"red",
-      6=>"blue",
-      7=>"orange"
-    } # Color scheme source: https://www.schemecolor.com/tetris-game-color-scheme.php
+    def initialize
+        # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
+        @tetrominos = [
+            Matrix[[1, 1, 1, 1]],
+            Matrix[[6, 0, 0], [6, 6, 6]],
+            Matrix[[0, 0, 7], [7, 7, 7]],
+            Matrix[[2, 2], [2, 2]],
+            Matrix[[0, 4, 4], [4, 4, 0]],
+            Matrix[[0, 3, 0], [3, 3, 3]],
+            Matrix[[5, 5, 0], [0, 5, 5]]
+        ]
+        
+        @color_map = {
+            1=>"aqua",
+            2=>"yellow",
+            3=>"purple",
+            4=>"green",
+            5=>"red",
+            6=>"blue",
+            7=>"orange"
+        } # Color scheme source: https://www.schemecolor.com/tetris-game-color-scheme.php
 
-    height = 20
-    width = 10
-    @gameboard = Matrix.zero(height, width)
-    gameboard.define_singleton_method(:height) {height}
-    gameboard.define_singleton_method(:width) {width}
-    @size = 50
+        height = 20
+        width = 10
+        @gameboard = Matrix.zero(height, width)
+        gameboard.define_singleton_method(:height) {height}
+        gameboard.define_singleton_method(:width) {width}
+        @size = 50
 
-    pos = [0, 0]
-    @tetromino = Tetromino.new(gameboard, tetrominos.sample, [0, 0])
-    tetromino.put_tetromino
-  end
-
-  def draw(start_pos, size) # size is the side length of a square
-    (0...gameboard.width).each do |i|
-      (0...gameboard.height).each do |j|
-        # the color is white if the gameboard space is empty, otherwise the color is the matching color on the color_map hash.
-        color = gameboard[j, i] == 0 ? "white" : color_map[gameboard[j, i]] 
-        # draws a square starting at point (x, y) with side length size and color color. z is the layer (the higher z is, the higher on the layers the shape is)
-        Square.new(
-          x: start_pos[0] + size*i, y: start_pos[1] + size*j,
-          size: size,
-          color: color,
-          z: 10
-        )
-      end
+        pos = [0, 0]
+        @tetromino = Tetromino.new(gameboard, tetrominos.sample, [0, 0])
+        tetromino.put_tetromino
     end
-  end
+
+    def draw(start_pos, size) # size is the side length of a square
+        (0...gameboard.width).each do |i|
+            (0...gameboard.height).each do |j|
+                # the color is white if the gameboard space is empty, otherwise the color is the matching color on the color_map hash.
+                color = gameboard[j, i] == 0 ? "white" : color_map[gameboard[j, i]] 
+                # draws a square starting at point (x, y) with side length size and color color. z is the layer (the higher z is, the higher on the layers the shape is)
+                Square.new(
+                    x: start_pos[0] + size*i, y: start_pos[1] + size*j,
+                    size: size,
+                    color: color,
+                    z: 10
+                )
+            end
+        end
+    end
 end

--- a/game.rb
+++ b/game.rb
@@ -1,54 +1,54 @@
 class Game
-  attr_reader :tetromino_shapes, :tetromino, :color_map, :size
-  attr_accessor :gameboard
+    attr_reader :tetrominos, :color_map, :size
+    attr_accessor :gameboard, :tetromino
 
-  def initialize
-    # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
-    @tetromino_shapes = [
-      Matrix[[1, 1, 1, 1]],
-      Matrix[[6, 0, 0], [6, 6, 6]],
-      Matrix[[0, 0, 7], [7, 7, 7]],
-      Matrix[[2, 2], [2, 2]],
-      Matrix[[0, 4, 4], [4, 4, 0]],
-      Matrix[[0, 3, 0], [3, 3, 3]],
-      Matrix[[5, 5, 0], [0, 5, 5]]
-    ]
-    
-    @color_map = {
-      1=>"aqua",
-      2=>"yellow",
-      3=>"purple",
-      4=>"green",
-      5=>"red",
-      6=>"blue",
-      7=>"orange"
-    } # Color scheme source: https://www.schemecolor.com/tetris-game-color-scheme.php
+    def initialize
+        # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
+        @tetrominos = [
+            Matrix[[1, 1, 1, 1]],
+            Matrix[[6, 0, 0], [6, 6, 6]],
+            Matrix[[0, 0, 7], [7, 7, 7]],
+            Matrix[[2, 2], [2, 2]],
+            Matrix[[0, 4, 4], [4, 4, 0]],
+            Matrix[[0, 3, 0], [3, 3, 3]],
+            Matrix[[5, 5, 0], [0, 5, 5]]
+        ]
+        
+        @color_map = {
+            1=>"aqua",
+            2=>"yellow",
+            3=>"purple",
+            4=>"green",
+            5=>"red",
+            6=>"blue",
+            7=>"orange"
+        } # Color scheme source: https://www.schemecolor.com/tetris-game-color-scheme.php
 
-    height = 20
-    width = 10
-    @gameboard = Matrix.zero(height, width)
-    gameboard.define_singleton_method(:height) {height}
-    gameboard.define_singleton_method(:width) {width}
-    @size = 50
+        height = 20
+        width = 10
+        @gameboard = Matrix.zero(height, width)
+        gameboard.define_singleton_method(:height) {height}
+        gameboard.define_singleton_method(:width) {width}
+        @size = 50
 
-    pos = [0, 0]
-    @tetromino = Tetromino.new(gameboard, tetromino_shapes.sample, [0, 0])
-    tetromino.put_tetromino
-  end
-
-  def draw(start_pos, size) # size is the side length of a square
-    (0...gameboard.width).each do |i|
-      (0...gameboard.height).each do |j|
-        # the color is white if the gameboard space is empty, otherwise the color is the matching color on the color_map hash.
-        color = gameboard[j, i] == 0 ? "white" : color_map[gameboard[j, i]] 
-        # draws a square starting at point (x, y) with side length size and color color. z is the layer (the higher z is, the higher on the layers the shape is)
-        Square.new(
-          x: start_pos[0] + size*i, y: start_pos[1] + size*j,
-          size: size,
-          color: color,
-          z: 10
-        )
-      end
+        pos = [0, 0]
+        @tetromino = Tetromino.new(gameboard, tetrominos.sample, [0, 0])
+        tetromino.put_tetromino
     end
-  end
+
+    def draw(start_pos, size) # size is the side length of a square
+        (0...gameboard.width).each do |i|
+            (0...gameboard.height).each do |j|
+                # the color is white if the gameboard space is empty, otherwise the color is the matching color on the color_map hash.
+                color = gameboard[j, i] == 0 ? "white" : color_map[gameboard[j, i]] 
+                # draws a square starting at point (x, y) with side length size and color color. z is the layer (the higher z is, the higher on the layers the shape is)
+                Square.new(
+                    x: start_pos[0] + size*i, y: start_pos[1] + size*j,
+                    size: size,
+                    color: color,
+                    z: 10
+                )
+            end
+        end
+    end
 end

--- a/game.rb
+++ b/game.rb
@@ -1,54 +1,54 @@
 class Game
-    attr_reader :tetrominos, :color_map, :size
-    attr_accessor :gameboard, :tetromino
+  attr_reader :tetrominos, :color_map, :size
+  attr_accessor :gameboard, :tetromino
 
-    def initialize
-        # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
-        @tetrominos = [
-            Matrix[[1, 1, 1, 1]],
-            Matrix[[6, 0, 0], [6, 6, 6]],
-            Matrix[[0, 0, 7], [7, 7, 7]],
-            Matrix[[2, 2], [2, 2]],
-            Matrix[[0, 4, 4], [4, 4, 0]],
-            Matrix[[0, 3, 0], [3, 3, 3]],
-            Matrix[[5, 5, 0], [0, 5, 5]]
-        ]
-        
-        @color_map = {
-            1=>"aqua",
-            2=>"yellow",
-            3=>"purple",
-            4=>"green",
-            5=>"red",
-            6=>"blue",
-            7=>"orange"
-        } # Color scheme source: https://www.schemecolor.com/tetris-game-color-scheme.php
+  def initialize
+    # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
+    @tetrominos = [
+      Matrix[[1, 1, 1, 1]],
+      Matrix[[6, 0, 0], [6, 6, 6]],
+      Matrix[[0, 0, 7], [7, 7, 7]],
+      Matrix[[2, 2], [2, 2]],
+      Matrix[[0, 4, 4], [4, 4, 0]],
+      Matrix[[0, 3, 0], [3, 3, 3]],
+      Matrix[[5, 5, 0], [0, 5, 5]]
+    ]
+    
+    @color_map = {
+      1=>"aqua",
+      2=>"yellow",
+      3=>"purple",
+      4=>"green",
+      5=>"red",
+      6=>"blue",
+      7=>"orange"
+    } # Color scheme source: https://www.schemecolor.com/tetris-game-color-scheme.php
 
-        height = 20
-        width = 10
-        @gameboard = Matrix.zero(height, width)
-        gameboard.define_singleton_method(:height) {height}
-        gameboard.define_singleton_method(:width) {width}
-        @size = 50
+    height = 20
+    width = 10
+    @gameboard = Matrix.zero(height, width)
+    gameboard.define_singleton_method(:height) {height}
+    gameboard.define_singleton_method(:width) {width}
+    @size = 50
 
-        pos = [0, 0]
-        @tetromino = Tetromino.new(gameboard, tetrominos.sample, [0, 0])
-        tetromino.put_tetromino
+    pos = [0, 0]
+    @tetromino = Tetromino.new(gameboard, tetrominos.sample, [0, 0])
+    tetromino.put_tetromino
+  end
+
+  def draw(start_pos, size) # size is the side length of a square
+    (0...gameboard.width).each do |i|
+      (0...gameboard.height).each do |j|
+        # the color is white if the gameboard space is empty, otherwise the color is the matching color on the color_map hash.
+        color = gameboard[j, i] == 0 ? "white" : color_map[gameboard[j, i]] 
+        # draws a square starting at point (x, y) with side length size and color color. z is the layer (the higher z is, the higher on the layers the shape is)
+        Square.new(
+          x: start_pos[0] + size*i, y: start_pos[1] + size*j,
+          size: size,
+          color: color,
+          z: 10
+        )
+      end
     end
-
-    def draw(start_pos, size) # size is the side length of a square
-        (0...gameboard.width).each do |i|
-            (0...gameboard.height).each do |j|
-                # the color is white if the gameboard space is empty, otherwise the color is the matching color on the color_map hash.
-                color = gameboard[j, i] == 0 ? "white" : color_map[gameboard[j, i]] 
-                # draws a square starting at point (x, y) with side length size and color color. z is the layer (the higher z is, the higher on the layers the shape is)
-                Square.new(
-                    x: start_pos[0] + size*i, y: start_pos[1] + size*j,
-                    size: size,
-                    color: color,
-                    z: 10
-                )
-            end
-        end
-    end
+  end
 end

--- a/tetris.rb
+++ b/tetris.rb
@@ -16,25 +16,25 @@ set height: size*game.gameboard.height
 
 t = 1
 update do
-  if t % 8 == 0
-    game.tetromino.moved = false
-  end
+    if t % 15 == 0
+        game.tetromino.moved = false
+    end
 
-  if t % 30 == 0
-    game.draw([0, 0], size)
-    game.tetromino.fall
-    game.gameboard = game.tetromino.gameboard
-  end
+    if t % 30 == 0
+        game.draw([0, 0], size)
+        game.tetromino.fall
+        game.gameboard = game.tetromino.gameboard
+    end
 
-  t += 1
+    t += 1
 end
 
 on :key_held do |event|
-  if !game.tetromino.moved
-    game.tetromino.moved = game.tetromino.move(event.key)
-    game.gameboard = game.tetromino.gameboard
-    game.draw([0, 0], size)
-  end
+    if !game.tetromino.moved
+        game.tetromino.moved = game.tetromino.move(event.key)
+        game.gameboard = game.tetromino.gameboard
+        game.draw([0, 0], size)
+    end
 end
 
 show

--- a/tetris.rb
+++ b/tetris.rb
@@ -16,25 +16,25 @@ set height: size*game.gameboard.height
 
 t = 1
 update do
-    if t % 15 == 0
-        game.tetromino.moved = false
-    end
+  if t % 15 == 0
+    game.tetromino.moved = false
+  end
 
-    if t % 30 == 0
-        game.draw([0, 0], size)
-        game.tetromino.fall
-        game.gameboard = game.tetromino.gameboard
-    end
+  if t % 30 == 0
+    game.draw([0, 0], size)
+    game.tetromino.fall
+    game.gameboard = game.tetromino.gameboard
+  end
 
-    t += 1
+  t += 1
 end
 
 on :key_held do |event|
-    if !game.tetromino.moved
-        game.tetromino.moved = game.tetromino.move(event.key)
-        game.gameboard = game.tetromino.gameboard
-        game.draw([0, 0], size)
-    end
+  if !game.tetromino.moved
+    game.tetromino.moved = game.tetromino.move(event.key)
+    game.gameboard = game.tetromino.gameboard
+    game.draw([0, 0], size)
+  end
 end
 
 show

--- a/tetris.rb
+++ b/tetris.rb
@@ -3,22 +3,31 @@ require "matrix" # matrix is installed when you install ruby, no need to use gem
 require_relative "tetrominos"
 require_relative "game"
 
-game = Game.new
 
-set title: "Tetrominos"
-set width: 500
-set height: 1000
+game = Game.new
 
 size = 50
 
+set title: "Tetrominos"
+set width: size*game.gameboard.width
+set height: size*game.gameboard.height
+
 t = 1
 update do
-  if t % 30 == 0
-    game.draw([0, 0], size)
-    game.tetromino.fall
-    game.gameboard = game.tetromino.gameboard
-  end
-  t += 1
+    if t % 30 == 0
+        game.draw([0, 0], size)
+        game.tetromino.fall
+        game.gameboard = game.tetromino.gameboard
+        game.tetromino.moved = false
+    end
+
+    on :key_down do |event|
+        if !game.tetromino.moved
+            game.tetromino.moved = game.tetromino.move(event.key)
+        end
+    end
+
+    t += 1
 end
 
 show

--- a/tetris.rb
+++ b/tetris.rb
@@ -8,26 +8,33 @@ game = Game.new
 
 size = 50
 
-set title: "Tetrominos"
+set title: "Tetris"
 set width: size*game.gameboard.width
 set height: size*game.gameboard.height
 
+
+
 t = 1
 update do
-    if t % 30 == 0
-        game.draw([0, 0], size)
-        game.tetromino.fall
-        game.gameboard = game.tetromino.gameboard
-        game.tetromino.moved = false
-    end
+  if t % 8 == 0
+    game.tetromino.moved = false
+  end
 
-    on :key_down do |event|
-        if !game.tetromino.moved
-            game.tetromino.moved = game.tetromino.move(event.key)
-        end
-    end
+  if t % 30 == 0
+    game.draw([0, 0], size)
+    game.tetromino.fall
+    game.gameboard = game.tetromino.gameboard
+  end
 
-    t += 1
+  t += 1
+end
+
+on :key_held do |event|
+  if !game.tetromino.moved
+    game.tetromino.moved = game.tetromino.move(event.key)
+    game.gameboard = game.tetromino.gameboard
+    game.draw([0, 0], size)
+  end
 end
 
 show

--- a/tetrominos.rb
+++ b/tetrominos.rb
@@ -1,59 +1,71 @@
 require "matrix" # matrix is installed when you install ruby, no need to use gem. docs: https://ruby-doc.org/stdlib-2.5.1/libdoc/matrix/rdoc/Matrix.html
 
 class Tetromino # A tetromino is a tetris piece
-  attr_reader :piece_data, :color_map, :width, :height, :gameboard
-  attr_accessor :pos, :moved
+    attr_reader :piece_data, :color_map, :width, :height, :gameboard
+    attr_accessor :pos, :moved
 
-  def initialize(gameboard, piece_data, pos)
-    raise ArgumentError unless piece_data.is_a? Matrix
-    
-    @gameboard = gameboard
-    @pos = pos
-    @piece_data = piece_data
-    @width = piece_data.row(0).to_a.length
-    @height = piece_data.column(0).to_a.length
-    @moved = false
-  end
+    def initialize(gameboard, piece_data, pos)
+        raise ArgumentError unless piece_data.is_a? Matrix
+        
+        @gameboard = gameboard
+        @pos = pos
+        @piece_data = piece_data
+        @width = piece_data.row(0).to_a.length
+        @height = piece_data.column(0).to_a.length
+        @moved = false
+    end
 
-  def put_tetromino(clear=false)
-    (0...width).each do |i|
-      (0...height).each do |j|
-        if clear
-          gameboard[pos[0]+j, pos[1]+i] = 0
-        else
-          gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
+    def put_tetromino(clear=false)
+        (0...width).each do |i|
+            (0...height).each do |j|
+                if clear
+                    gameboard[pos[0]+j, pos[1]+i] = 0
+                else
+                    gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
+                end
+            end
         end
-      end
     end
-  end
 
-  def update(pos_index, inc)
-    put_tetromino(clear=true)
-    pos[pos_index] += inc
-    put_tetromino
-  end
-
-  def fall
-    if pos[0] + height != gameboard.height
-      update(0, 1)
+    def update(pos_index, inc)
+        put_tetromino(clear=true)
+        pos[pos_index] += inc
+        put_tetromino
     end
-  end
 
-  def move(dir)
-    case dir
-    when "left"
-      if pos[1] > 0
-        update(1, -1)
-        return true
-      end
-    when "right"
-      if pos[1] < gameboard.width - width
-        update(1, 1)
-        return true
-      end
-    else
-      return false
+    def fall
+        if pos[0] + height != gameboard.height
+            update(0, 1)
+        end
     end
-    false
-  end
+
+    def move(dir)
+        case dir
+        when "left"
+            if pos[1] > 0
+                update(1, -1)
+                return true
+            end
+        when "right"
+            if pos[1] < gameboard.width - width
+                update(1, 1)
+                return true
+            end
+        when "up"
+            rotate
+            return true
+        else
+            return false
+        end
+        false
+    end
+
+    def rotate
+        height % 2 == 0 ? update(0, -(height / 2)) : update(0, -(height / 2 - 1))
+        put_tetromino(clear=true)
+        @piece_data = Matrix[*(0...width).map {|i| piece_data.transpose.row(i).to_a.reverse}] # Matrix.transpose almost rotates, but we need to reverse each row. Asterix to prevent everything to be nested in one []
+        @width = piece_data.row(0).to_a.length
+        @height = piece_data.column(0).to_a.length
+        put_tetromino
+    end
 end

--- a/tetrominos.rb
+++ b/tetrominos.rb
@@ -1,64 +1,59 @@
 require "matrix" # matrix is installed when you install ruby, no need to use gem. docs: https://ruby-doc.org/stdlib-2.5.1/libdoc/matrix/rdoc/Matrix.html
 
 class Tetromino # A tetromino is a tetris piece
-    attr_reader :piece_data, :color_map, :width, :height, :gameboard
-    attr_accessor :pos, :moved
+  attr_reader :piece_data, :color_map, :width, :height, :gameboard
+  attr_accessor :pos, :moved
 
-    def initialize(gameboard, piece_data, pos)
-        raise ArgumentError unless piece_data.is_a? Matrix
-        
-        @gameboard = gameboard
-        @pos = pos
-        @piece_data = piece_data
-        @width = piece_data.row(0).to_a.length
-        @height = piece_data.column(0).to_a.length
-        @moved = false
-    end
+  def initialize(gameboard, piece_data, pos)
+    raise ArgumentError unless piece_data.is_a? Matrix
+    
+    @gameboard = gameboard
+    @pos = pos
+    @piece_data = piece_data
+    @width = piece_data.row(0).to_a.length
+    @height = piece_data.column(0).to_a.length
+    @moved = false
+  end
 
-    def put_tetromino(clear=false)
-        (0...width).each do |i|
-            (0...height).each do |j|
-                if clear
-                    gameboard[pos[0]+j, pos[1]+i] = 0
-                else
-                    gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
-                end
-            end
-        end
-    end
-
-    def fall
-        if pos[0] + height != gameboard.height
-            put_tetromino(clear=true)
-            pos[0] += 1
-            put_tetromino
-        end
-    end
-
-    def move(dir)
-        case dir
-        when "left"
-            if pos[1] > 0
-                put_tetromino(clear=true)
-                pos[1] -= 1
-                put_tetromino
-                return true
-            end
-            return false
-        when "right"
-            if pos[1] < gameboard.width - width
-                put_tetromino(clear=true)
-                pos[1] += 1
-                put_tetromino
-                return true
-            end
-            return false
-        when "down"
-            # adding acelleration later
-            return false
+  def put_tetromino(clear=false)
+    (0...width).each do |i|
+      (0...height).each do |j|
+        if clear
+          gameboard[pos[0]+j, pos[1]+i] = 0
         else
-            return false
+          gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
         end
-        false
+      end
     end
+  end
+
+  def update(pos_index, inc)
+    put_tetromino(clear=true)
+    pos[pos_index] += inc
+    put_tetromino
+  end
+
+  def fall
+    if pos[0] + height != gameboard.height
+      update(0, 1)
+    end
+  end
+
+  def move(dir)
+    case dir
+    when "left"
+      if pos[1] > 0
+        update(1, -1)
+        return true
+      end
+    when "right"
+      if pos[1] < gameboard.width - width
+        update(1, 1)
+        return true
+      end
+    else
+      return false
+    end
+    false
+  end
 end

--- a/tetrominos.rb
+++ b/tetrominos.rb
@@ -1,71 +1,71 @@
 require "matrix" # matrix is installed when you install ruby, no need to use gem. docs: https://ruby-doc.org/stdlib-2.5.1/libdoc/matrix/rdoc/Matrix.html
 
 class Tetromino # A tetromino is a tetris piece
-    attr_reader :piece_data, :color_map, :width, :height, :gameboard
-    attr_accessor :pos, :moved
+  attr_reader :piece_data, :color_map, :width, :height, :gameboard
+  attr_accessor :pos, :moved
 
-    def initialize(gameboard, piece_data, pos)
-        raise ArgumentError unless piece_data.is_a? Matrix
-        
-        @gameboard = gameboard
-        @pos = pos
-        @piece_data = piece_data
-        @width = piece_data.row(0).to_a.length
-        @height = piece_data.column(0).to_a.length
-        @moved = false
-    end
+  def initialize(gameboard, piece_data, pos)
+    raise ArgumentError unless piece_data.is_a? Matrix
+    
+    @gameboard = gameboard
+    @pos = pos
+    @piece_data = piece_data
+    @width = piece_data.row(0).to_a.length
+    @height = piece_data.column(0).to_a.length
+    @moved = false
+  end
 
-    def put_tetromino(clear=false)
-        (0...width).each do |i|
-            (0...height).each do |j|
-                if clear
-                    gameboard[pos[0]+j, pos[1]+i] = 0
-                else
-                    gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
-                end
-            end
-        end
-    end
-
-    def update(pos_index, inc)
-        put_tetromino(clear=true)
-        pos[pos_index] += inc
-        put_tetromino
-    end
-
-    def fall
-        if pos[0] + height != gameboard.height
-            update(0, 1)
-        end
-    end
-
-    def move(dir)
-        case dir
-        when "left"
-            if pos[1] > 0
-                update(1, -1)
-                return true
-            end
-        when "right"
-            if pos[1] < gameboard.width - width
-                update(1, 1)
-                return true
-            end
-        when "up"
-            rotate
-            return true
+  def put_tetromino(clear=false)
+    (0...width).each do |i|
+      (0...height).each do |j|
+        if clear
+          gameboard[pos[0]+j, pos[1]+i] = 0
         else
-            return false
+          gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
         end
-        false
+      end
     end
+  end
 
-    def rotate
-        height % 2 == 0 ? update(0, -(height / 2)) : update(0, -(height / 2 - 1))
-        put_tetromino(clear=true)
-        @piece_data = Matrix[*(0...width).map {|i| piece_data.transpose.row(i).to_a.reverse}] # Matrix.transpose almost rotates, but we need to reverse each row. Asterix to prevent everything to be nested in one []
-        @width = piece_data.row(0).to_a.length
-        @height = piece_data.column(0).to_a.length
-        put_tetromino
+  def update(pos_index, inc)
+    put_tetromino(clear=true)
+    pos[pos_index] += inc
+    put_tetromino
+  end
+
+  def fall
+    if pos[0] + height != gameboard.height
+      update(0, 1)
     end
+  end
+
+  def move(dir)
+    case dir
+    when "left"
+      if pos[1] > 0
+        update(1, -1)
+        return true
+      end
+    when "right"
+      if pos[1] < gameboard.width - width
+        update(1, 1)
+        return true
+      end
+    when "up"
+      rotate
+      return true
+    else
+      return false
+    end
+    false
+  end
+
+  def rotate
+    height % 2 == 0 ? update(0, -(height / 2)) : update(0, -(height / 2 - 1))
+    put_tetromino(clear=true)
+    @piece_data = Matrix[*(0...width).map {|i| piece_data.transpose.row(i).to_a.reverse}] # Matrix.transpose almost rotates, but we need to reverse each row. Asterix to prevent everything to be nested in one []
+    @width = piece_data.row(0).to_a.length
+    @height = piece_data.column(0).to_a.length
+    put_tetromino
+  end
 end

--- a/tetrominos.rb
+++ b/tetrominos.rb
@@ -1,37 +1,64 @@
 require "matrix" # matrix is installed when you install ruby, no need to use gem. docs: https://ruby-doc.org/stdlib-2.5.1/libdoc/matrix/rdoc/Matrix.html
 
 class Tetromino # A tetromino is a tetris piece
-  attr_reader :piece_data, :color_map, :width, :height, :gameboard
-  attr_accessor :pos
+    attr_reader :piece_data, :color_map, :width, :height, :gameboard
+    attr_accessor :pos, :moved
 
-  def initialize(gameboard, piece_data, pos)
-    raise ArgumentError unless piece_data.is_a? Matrix
-    
-    @gameboard = gameboard
-    @pos = pos
-    @piece_data = piece_data
-    @width = piece_data.row(0).to_a.length
-    @height = piece_data.column(0).to_a.length
-  end
+    def initialize(gameboard, piece_data, pos)
+        raise ArgumentError unless piece_data.is_a? Matrix
+        
+        @gameboard = gameboard
+        @pos = pos
+        @piece_data = piece_data
+        @width = piece_data.row(0).to_a.length
+        @height = piece_data.column(0).to_a.length
+        @moved = false
+    end
 
-  def put_tetromino(clear=false)
-    (0...width).each do |i|
-      (0...height).each do |j|
-        if clear
-          gameboard[pos[0]+j, pos[1]+i] = 0
-        else
-          gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
+    def put_tetromino(clear=false)
+        (0...width).each do |i|
+            (0...height).each do |j|
+                if clear
+                    gameboard[pos[0]+j, pos[1]+i] = 0
+                else
+                    gameboard[pos[0]+j, pos[1]+i] = piece_data[j, i]
+                end
+            end
         end
-      end
     end
-  end
 
-  def fall
-    if pos[0] + height != gameboard.height
-      put_tetromino(clear=true)
-      pos[0] += 1
-      put_tetromino
+    def fall
+        if pos[0] + height != gameboard.height
+            put_tetromino(clear=true)
+            pos[0] += 1
+            put_tetromino
+        end
     end
-  end
 
+    def move(dir)
+        case dir
+        when "left"
+            if pos[1] > 0
+                put_tetromino(clear=true)
+                pos[1] -= 1
+                put_tetromino
+                return true
+            end
+            return false
+        when "right"
+            if pos[1] < gameboard.width - width
+                put_tetromino(clear=true)
+                pos[1] += 1
+                put_tetromino
+                return true
+            end
+            return false
+        when "down"
+            # adding acelleration later
+            return false
+        else
+            return false
+        end
+        false
+    end
 end


### PR DESCRIPTION
Tetromino can now rotate, using the Matrix.transpose method and some mapping to reverse each row (transposing doesn't actually rotate).

If you spam up arrow (the rotate button), you won't actually fall, but this can be changed because eventually we will be implementing accelerated falling.

I'm making this a draft because my previous pull request hasn't been approved, and I don't want this one approved before that one.