### PR TITLE
Remove filled rows

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -26,14 +26,6 @@ class Game
     @gameboard_height = gameboard_height
     @gameboard_width = gameboard_width
     @gameboard = Matrix.zero(gameboard_height, gameboard_width)
-    (0...10).each do |i|
-      @gameboard[-1, i] = 1
-    end
-    (0...10).each do |i|
-      @gameboard[-2, i] = 1
-    end
-    @gameboard[-1, 5] = 0
-    @gameboard[-2, 5] = 0
     @squares = Matrix.zero(gameboard_height, gameboard_width)
 
     create_tetromino()

--- a/game.rb
+++ b/game.rb
@@ -26,6 +26,14 @@ class Game
     @gameboard_height = gameboard_height
     @gameboard_width = gameboard_width
     @gameboard = Matrix.zero(gameboard_height, gameboard_width)
+    (0...10).each do |i|
+      @gameboard[-1, i] = 1
+    end
+    (0...10).each do |i|
+      @gameboard[-2, i] = 1
+    end
+    @gameboard[-1, 5] = 0
+    @gameboard[-2, 5] = 0
     @squares = Matrix.zero(gameboard_height, gameboard_width)
 
     create_tetromino()
@@ -38,6 +46,26 @@ class Game
   def create_tetromino()
     @tetromino = Tetromino.new(@gameboard, @tetromino_shapes.sample, [0, 0], @gameboard_height, @gameboard_width)
     @gameboard = tetromino.put_tetromino(@gameboard, [0, 0], tetromino.width, tetromino.height)
+  end
+
+  def move_all_down(row)
+    (row - 1).downto(-@gameboard_height).each do |i|
+      (0...@gameboard_width).each do |j|
+        @gameboard[i+1, j] = @gameboard[i, j] # set current position in line below current line to current position in the current line
+        @gameboard[i, j] = 0 # set current position in current line to zero
+      end
+    end
+  end
+
+  def remove_filled_rows
+    -1.downto(-@gameboard_height).each do |row|
+      while !@gameboard.row(row).include?(0) # while row is full
+        (0...@gameboard_width).each {|i| @gameboard[row, i] = 0} # set the line to all zeros
+        unless row == -@gameboard_height # top row doesn't have anything above it, so no need to move stuff down.
+          move_all_down(row)
+        end
+      end
+    end
   end
 
   def draw(start_pos, size) # size is the side length of a square

--- a/tetris.rb
+++ b/tetris.rb
@@ -22,7 +22,8 @@ update do
 
   if t % 30 == 0
     if game.tetromino.dead
-      game.create_tetromino()
+      game.remove_filled_rows
+      game.create_tetromino
     end
     game.draw([0, 0], size)
     game.tetromino.fall


### PR DESCRIPTION
closes #31 
closes #39 

A filled row is one not consisting of zeros. In other words, a filled row is completely filled with squares. 

2 methods have been added to `Game` in `game.rb`. 
1. `remove_filled_rows`, which goes through each row, checks if it's filled, and sets that row to zeros, along with all filled rows above it.
2. `move_all_down` moves everything above a certain row down one row. This is to fill in the line(s) of zeros created by `remove_filled_rows`. `move_all_down` is called inside `remove_filled_rows`.

These changes remove filled rows at any position on the gameboard, not just the last row. They also remove multiple filled rows in one tick.