### PR TITLE
Add downwards drop and acceleration

### DIFF
--- a/tetris.rb
+++ b/tetris.rb
@@ -16,11 +16,15 @@ set height: size*gameboard_height
 
 t = 1
 update do
-  if t % 12 == 0
+  begin
+    if t % (10 / game.tetromino.fall_rate) == 0
+      game.tetromino.moved = false
+    end
+  rescue
     game.tetromino.moved = false
   end
 
-  if t % 30 == 0
+  if t % (60 / game.tetromino.fall_rate) == 0
     if game.tetromino.dead
       game.remove_filled_rows
       game.create_tetromino
@@ -28,13 +32,22 @@ update do
     game.draw([0, 0], size)
     game.tetromino.fall
     game.update_gameboard
+    game.tetromino.reset_fall_rate
   end
 
   t += 1
 end
 
+on :key_held do |event|
+  if event.key == "down"
+    game.tetromino.moved = game.tetromino.move(event.key)
+    game.update_gameboard
+    game.draw([0, 0], size)
+  end
+end
+
 on :key_down do |event|
-  if !game.tetromino.moved
+  if ["left", "right", "up", "space"].include?(event.key)
     game.tetromino.moved = game.tetromino.move(event.key)
     game.update_gameboard
     game.draw([0, 0], size)

--- a/tetromino.rb
+++ b/tetromino.rb
@@ -74,7 +74,7 @@ class Tetromino # A tetromino is a tetris piece
 
   def reset_fall_rate
     if @accelerated
-      @fall_rate /= 3
+      @fall_rate /= 5
     end
     @accelerated = false
   end
@@ -95,7 +95,7 @@ class Tetromino # A tetromino is a tetris piece
       return rotate
     when "down"
       if !@accelerated
-        @fall_rate *= 4
+        @fall_rate *= 5
         @accelerated = true
       end
       return @accelerated

--- a/tetromino.rb
+++ b/tetromino.rb
@@ -1,7 +1,7 @@
 require "matrix" # matrix is installed when you install ruby, no need to use gem. docs: https://ruby-doc.org/stdlib-2.5.1/libdoc/matrix/rdoc/Matrix.html
 
 class Tetromino # A tetromino is a tetris piece
-  attr_reader :piece_data, :width, :height, :pos, :gameboard, :dead
+  attr_reader :piece_data, :width, :height, :pos, :gameboard, :dead, :fall_rate
   attr_accessor :moved
 
   def initialize(gameboard, piece_data, pos, gameboard_height, gameboard_width)
@@ -16,6 +16,8 @@ class Tetromino # A tetromino is a tetris piece
     @height = piece_data.column(0).to_a.length
     @moved = false
     @dead = false
+    @fall_rate = 2 # ticks per second
+    @accelerated = false
   end
 
   def put_tetromino(_gameboard=gameboard, _pos=pos, _width=width, _height=height, _piece_data=piece_data, clear=false)
@@ -70,6 +72,13 @@ class Tetromino # A tetromino is a tetris piece
     end
   end
 
+  def reset_fall_rate
+    if @accelerated
+      @fall_rate /= 3
+    end
+    @accelerated = false
+  end
+
   def move(dir)
     case dir
     when "left"
@@ -84,8 +93,17 @@ class Tetromino # A tetromino is a tetris piece
       end
     when "up"
       return rotate
-    else
-      return false
+    when "down"
+      if !@accelerated
+        @fall_rate *= 4
+        @accelerated = true
+      end
+      return @accelerated
+    when "space"
+      while !dead
+        fall
+      end
+      return true
     end
     false
   end


### PR DESCRIPTION
closes #43 

You can now press the down arrow to accelerate the tetromino downwards. You can also press the space bar to instantly drop the tetromino to the lowest available space in the current x position.

I now realize I accidentally closed #25 in this PR too. Yay! 