### PR TITLE
Improve scoring

### DIFF
--- a/game.rb
+++ b/game.rb
@@ -41,7 +41,7 @@ class Game
   def create_tetromino()
     piece_data = @tetromino_shapes.sample
     pos = [0, @gameboard_width / 2 - piece_data.row(0).to_a.length / 2]
-    @tetromino = Tetromino.new(@gameboard, piece_data, pos, @gameboard_height, @gameboard_width)
+    @tetromino = Tetromino.new(@gameboard, piece_data, pos, @gameboard_height, @gameboard_width, @scoreboard)
     @gameboard = tetromino.put_tetromino(@gameboard, pos, tetromino.width, tetromino.height)
   end
 

--- a/game.rb
+++ b/game.rb
@@ -7,13 +7,13 @@ class Game
 
     # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
     @tetromino_shapes = [
-      Matrix[[1, 1, 1, 1]]
-      #Matrix[[6, 0, 0], [6, 6, 6]],
-      #Matrix[[0, 0, 7], [7, 7, 7]],
-      #Matrix[[2, 2], [2, 2]],
-      #Matrix[[0, 4, 4], [4, 4, 0]],
-      #Matrix[[0, 3, 0], [3, 3, 3]],
-      #Matrix[[5, 5, 0], [0, 5, 5]]
+      Matrix[[1, 1, 1, 1]],
+      Matrix[[6, 0, 0], [6, 6, 6]],
+      Matrix[[0, 0, 7], [7, 7, 7]],
+      Matrix[[2, 2], [2, 2]],
+      Matrix[[0, 4, 4], [4, 4, 0]],
+      Matrix[[0, 3, 0], [3, 3, 3]],
+      Matrix[[5, 5, 0], [0, 5, 5]]
     ]
     
     @color_map = {

--- a/game.rb
+++ b/game.rb
@@ -7,13 +7,13 @@ class Game
 
     # tetrominos from https://user-images.githubusercontent.com/124208/127236186-733e6247-0824-4b2e-b464-552cd700bb65.png
     @tetromino_shapes = [
-      Matrix[[1, 1, 1, 1]],
-      Matrix[[6, 0, 0], [6, 6, 6]],
-      Matrix[[0, 0, 7], [7, 7, 7]],
-      Matrix[[2, 2], [2, 2]],
-      Matrix[[0, 4, 4], [4, 4, 0]],
-      Matrix[[0, 3, 0], [3, 3, 3]],
-      Matrix[[5, 5, 0], [0, 5, 5]]
+      Matrix[[1, 1, 1, 1]]
+      #Matrix[[6, 0, 0], [6, 6, 6]],
+      #Matrix[[0, 0, 7], [7, 7, 7]],
+      #Matrix[[2, 2], [2, 2]],
+      #Matrix[[0, 4, 4], [4, 4, 0]],
+      #Matrix[[0, 3, 0], [3, 3, 3]],
+      #Matrix[[5, 5, 0], [0, 5, 5]]
     ]
     
     @color_map = {
@@ -62,12 +62,15 @@ class Game
         unless row == -@gameboard_height # top row doesn't have anything above it, so no need to move stuff down.
           move_all_down(row)
         end
-        @scoreboard.score_row
         row_count += 1
       end
     end
     if row_count == 4 
       @scoreboard.score_tetris
+    else
+      row_count.times do
+        @scoreboard.score_row
+      end
     end
   end
 

--- a/scoreboard.rb
+++ b/scoreboard.rb
@@ -16,6 +16,7 @@ class Scoreboard
       color: 'black',
       z: 10
     )
+    @prev_tetris = false
   end
 
   def reset_boom_text
@@ -39,11 +40,16 @@ class Scoreboard
   def score_row
     @score += 100
     update_score_text
+    @prev_tetris = false
   end
 
   def score_tetris
-    @score += 400
+    @score += 800
+    if @prev_tetris
+      @score += 200
+    end
     update_score_text
     @boom_text.text = "TETRIS!"
+    @prev_tetris = true
   end
 end

--- a/scoreboard.rb
+++ b/scoreboard.rb
@@ -5,28 +5,45 @@ class Scoreboard
     @text = Text.new(
       'Score: 0',
       x: 0, y: 0,
-      size: 20,
+      size: 30,
       color: 'black',
       z: 10
     )
     @boom_text = Text.new(
       '',
       x: 200, y: 0,
-      size: 20,
+      size: 30,
       color: 'black',
       z: 10
     )
   end
 
-  def score_row
-    @score += 1
-    @text.text = "Score #{@score}"
+  def reset_boom_text
     @boom_text.text = ""
   end
 
+  def update_score_text
+    @text.text = "Score: #{@score}"
+  end
+
+  def score_acceleration
+    @score += 1
+    update_score_text
+  end
+
+  def score_hard_drop(dis)
+    @score += 2*dis
+    update_score_text
+  end
+
+  def score_row
+    @score += 100
+    update_score_text
+  end
+
   def score_tetris
-    @score += 4
-    @text.text = "Score #{@score}"
+    @score += 400
+    update_score_text
     @boom_text.text = "TETRIS!"
   end
 end

--- a/scoreboard.rb
+++ b/scoreboard.rb
@@ -1,9 +1,13 @@
 class Scoreboard
+  attr_reader :level
+
   def initialize(gameboard_width, gameboard_height)
     @score = 0
+    @lines_cleared = 0
+    @level = 1
     # x_pos = Window.width / 2
     @text = Text.new(
-      'Score: 0',
+      'Level: 1 Score: 0',
       x: 0, y: 0,
       size: 30,
       color: 'black',
@@ -11,7 +15,7 @@ class Scoreboard
     )
     @boom_text = Text.new(
       '',
-      x: 200, y: 0,
+      x: 280, y: 0,
       size: 30,
       color: 'black',
       z: 10
@@ -23,32 +27,35 @@ class Scoreboard
     @boom_text.text = ""
   end
 
-  def update_score_text
-    @text.text = "Score: #{@score}"
+  def update
+    @level = @lines_cleared/5 + 1 # Update level
+    @text.text = "Level: #{@level} Score: #{@score}" # Update text
   end
 
   def score_acceleration
-    @score += 1
-    update_score_text
+    @score += 1*level
+    update
   end
 
   def score_hard_drop(dis)
-    @score += 2*dis
-    update_score_text
+    @score += 2*dis*level
+    update
   end
 
   def score_row
-    @score += 100
-    update_score_text
+    @score += 100*level
+    @lines_cleared += 1
+    update
     @prev_tetris = false
   end
 
   def score_tetris
-    @score += 800
+    @score += 800*level
     if @prev_tetris
-      @score += 200
+      @score += 200*level
     end
-    update_score_text
+    @lines_cleared += 8
+    update
     @boom_text.text = "TETRIS!"
     @prev_tetris = true
   end

--- a/scoreboard.rb
+++ b/scoreboard.rb
@@ -9,14 +9,14 @@ class Scoreboard
     @text = Text.new(
       'Level: 1 Score: 0',
       x: 0, y: 0,
-      size: 30,
+      size: 27,
       color: 'black',
       z: 10
     )
     @boom_text = Text.new(
       '',
-      x: 280, y: 0,
-      size: 30,
+      x: 290, y: 0,
+      size: 27,
       color: 'black',
       z: 10
     )

--- a/tetris.rb
+++ b/tetris.rb
@@ -28,16 +28,14 @@ update do
   if !game_over
     if game.tetromino.hard_dead
       if game.tetromino.pos[0] == 0 # if the tetromino died when still at highest y level
-        game.gameboard = Gameboard.zero(20, 10)
-        game.draw([0, 40], size)
-        set background: "red"
+        set background: "random"
         Text.new(
           "GAME OVER",
-          x: 0,
+          x: 50,
           y: size*gameboard_height / 2,
           size: 50,
           color: 'black',
-          z: 10
+          z: 100
         )
         game_over = true
         game_over_tick = t
@@ -66,27 +64,35 @@ update do
       game.tetromino.reset_fall_rate
       game.tetromino.update_fall_rate
     end
+  else
+    if t % 20 == 0
+      set background: "random"
+    end
   end
 
   t += 1
 end
 
 on :key_down do |event|
-  if ["left", "right", "up", "space"].include?(event.key)
-    if (!game.tetromino.moved && t % 15 == 0) || ["up", "space"].include?(event.key)
-      game.tetromino.moved = game.tetromino.move(event.key)
-      game.update_gameboard
-      game.draw([0, 40], size)
+  if !game_over
+    if ["left", "right", "up", "space"].include?(event.key)
+      if (!game.tetromino.moved && t % 15 == 0) || ["up", "space"].include?(event.key)
+        game.tetromino.moved = game.tetromino.move(event.key)
+        game.update_gameboard
+        game.draw([0, 40], size)
+      end
     end
   end
 end
 
 on :key_held do |event|
-  if ["left", "right", "down"].include?(event.key)
-    if t % 5 == 0
-      game.tetromino.moved = game.tetromino.move(event.key)
-      game.update_gameboard
-      game.draw([0, 40], size)
+  if !game_over
+    if ["left", "right", "down"].include?(event.key)
+      if t % 5 == 0
+        game.tetromino.moved = game.tetromino.move(event.key)
+        game.update_gameboard
+        game.draw([0, 40], size)
+      end
     end
   end
 end

--- a/tetris.rb
+++ b/tetris.rb
@@ -26,40 +26,43 @@ t = 1
 
 update do
   if !game_over
+    if game.tetromino.hard_dead
+      if game.tetromino.pos[0] == 0 # if the tetromino died when still at highest y level
+        game.gameboard = Gameboard.zero(20, 10)
+        game.draw([0, 40], size)
+        set background: "red"
+        Text.new(
+          "GAME OVER",
+          x: 0,
+          y: size*gameboard_height / 2,
+          size: 50,
+          color: 'black',
+          z: 10
+        )
+        game_over = true
+        game_over_tick = t
+      else
+        game.remove_filled_rows
+        game.create_tetromino
+      end
+    end
+
     begin
-      if t % (10 / game.tetromino.fall_rate) == 0
+      if t % game.tetromino.fall_rate/6 == 0
         game.tetromino.moved = false
       end
-    rescue
+    rescue ZeroDivisionError
       game.tetromino.moved = false
     end
 
-    if t % (60 / game.tetromino.fall_rate) == 0
+    if t % game.tetromino.fall_rate == 0
       scoreboard.reset_boom_text
-      if game.tetromino.hard_dead
-        if game.tetromino.pos[0] == 0 # if the tetromino died when still at highest y level
-          game.gameboard = Gameboard.zero(20, 10)
-          game.draw([0, 40], size)
-          set background: "red"
-          Text.new(
-            "GAME OVER",
-            x: 0,
-            y: size*gameboard_height / 2,
-            size: 50,
-            color: 'black',
-            z: 10
-          )
-          game_over = true
-          game_over_tick = t
-        else
-          game.remove_filled_rows
-          game.create_tetromino
-        end
-      end
+
       game.draw([0, 40], size)
       game.tetromino.fall
       game.update_gameboard
       game.tetromino.reset_fall_rate
+      game.tetromino.update_fall_rate
     end
   end
 
@@ -68,24 +71,20 @@ end
 
 on :key_down do |event|
   if ["left", "right", "up", "space"].include?(event.key)
-    if !game.tetromino.moved
-      if t % 15 == 0 || ["up", "space"].include?(event.key)
-        game.tetromino.moved = game.tetromino.move(event.key)
-        game.update_gameboard
-        game.draw([0, 40], size)
-      end
+    if (!game.tetromino.moved && t % 15 == 0) || ["up", "space"].include?(event.key)
+      game.tetromino.moved = game.tetromino.move(event.key)
+      game.update_gameboard
+      game.draw([0, 40], size)
     end
   end
 end
 
 on :key_held do |event|
   if ["left", "right", "down"].include?(event.key)
-    if !game.tetromino.moved
-      if t % 5 == 0
-        game.tetromino.moved = game.tetromino.move(event.key)
-        game.update_gameboard
-        game.draw([0, 40], size)
-      end
+    if t % 5 == 0
+      game.tetromino.moved = game.tetromino.move(event.key)
+      game.update_gameboard
+      game.draw([0, 40], size)
     end
   end
 end

--- a/tetris.rb
+++ b/tetris.rb
@@ -55,9 +55,11 @@ update do
       game.tetromino.moved = false
     end
 
-    if t % game.tetromino.fall_rate == 0
+    if t % (game.tetromino.fall_rate * 10) == 0
       scoreboard.reset_boom_text
+    end
 
+    if t % game.tetromino.fall_rate == 0
       game.draw([0, 40], size)
       game.tetromino.fall
       game.update_gameboard

--- a/tetris.rb
+++ b/tetris.rb
@@ -18,7 +18,7 @@ game = Game.new(gameboard_height, gameboard_width, log, scoreboard)
 set title: "Tetris"
 set background: "white"
 set width: size*gameboard_width
-set height: size*gameboard_height+30
+set height: size*gameboard_height+40
 
 game_over = false
 game_over_tick = -1
@@ -35,10 +35,11 @@ update do
     end
 
     if t % (60 / game.tetromino.fall_rate) == 0
+      scoreboard.reset_boom_text
       if game.tetromino.hard_dead
         if game.tetromino.pos[0] == 0 # if the tetromino died when still at highest y level
           game.gameboard = Gameboard.zero(20, 10)
-          game.draw([0, 30], size)
+          game.draw([0, 40], size)
           set background: "red"
           Text.new(
             "GAME OVER",
@@ -55,7 +56,7 @@ update do
           game.create_tetromino
         end
       end
-      game.draw([0, 30], size)
+      game.draw([0, 40], size)
       game.tetromino.fall
       game.update_gameboard
       game.tetromino.reset_fall_rate
@@ -71,7 +72,7 @@ on :key_down do |event|
       if t % 15 == 0 || ["up", "space"].include?(event.key)
         game.tetromino.moved = game.tetromino.move(event.key)
         game.update_gameboard
-        game.draw([0, 30], size)
+        game.draw([0, 40], size)
       end
     end
   end
@@ -83,7 +84,7 @@ on :key_held do |event|
       if t % 5 == 0
         game.tetromino.moved = game.tetromino.move(event.key)
         game.update_gameboard
-        game.draw([0, 30], size)
+        game.draw([0, 40], size)
       end
     end
   end

--- a/tetromino.rb
+++ b/tetromino.rb
@@ -18,7 +18,7 @@ class Tetromino # A tetromino is a tetris piece
     @moved = false
     @soft_dead = false
     @hard_dead = false
-    @fall_rate = 2 # ticks per second
+    @fall_rate = 30 # will fall every @fall_rate/60 seconds
     @accelerated = false
   end
 
@@ -88,9 +88,15 @@ class Tetromino # A tetromino is a tetris piece
 
   def reset_fall_rate
     if @accelerated
-      @fall_rate /= 5
+      @fall_rate *= 8
     end
     @accelerated = false
+  end
+
+  def update_fall_rate
+    if @fall_rate != 1
+      @fall_rate = 32 - @scoreboard.level*2
+    end
   end
 
   def move(dir)
@@ -110,7 +116,7 @@ class Tetromino # A tetromino is a tetris piece
     when "down"
       if !@accelerated && !hard_dead # needs && !hard_dead so no extra score is added in the interval between tetromino dying and new tetromino spawning
         @scoreboard.score_acceleration
-        @fall_rate *= 5
+        @fall_rate /= 8 
         @accelerated = true
       end
       return @accelerated
@@ -134,7 +140,7 @@ class Tetromino # A tetromino is a tetris piece
     begin
       shadow_gameboard = put_tetromino(gameboardWithoutTetromino, pos, shadow_width, shadow_height, shadowPieceData)
       if collision_detect(shadow_gameboard, pos, [shadow_height, shadow_width], shadowPieceData)
-        @hard_dead = true
+        return false
       else
         @width = shadow_width
         @height = shadow_height

--- a/tetromino.rb
+++ b/tetromino.rb
@@ -95,7 +95,7 @@ class Tetromino # A tetromino is a tetris piece
 
   def update_fall_rate
     if @fall_rate != 1
-      @fall_rate = 32 - @scoreboard.level*2
+      @fall_rate = 32 - @scoreboard.level
     end
   end
 

--- a/tetromino.rb
+++ b/tetromino.rb
@@ -4,9 +4,10 @@ class Tetromino # A tetromino is a tetris piece
   attr_reader :piece_data, :width, :height, :pos, :gameboard, :soft_dead, :hard_dead, :fall_rate
   attr_accessor :moved
 
-  def initialize(gameboard, piece_data, pos, gameboard_height, gameboard_width)
+  def initialize(gameboard, piece_data, pos, gameboard_height, gameboard_width, scoreboard)
     raise ArgumentError unless piece_data.is_a? Matrix
     
+    @scoreboard = scoreboard
     @gameboard_height = gameboard_height
     @gameboard_width = gameboard_width
     @gameboard = gameboard
@@ -107,15 +108,19 @@ class Tetromino # A tetromino is a tetris piece
     when "up"
       return rotate
     when "down"
-      if !@accelerated
+      if !@accelerated && !hard_dead # needs && !hard_dead so no extra score is added in the interval between tetromino dying and new tetromino spawning
+        @scoreboard.score_acceleration
         @fall_rate *= 5
         @accelerated = true
       end
       return @accelerated
     when "space"
+      start_y = pos[0]
       while !hard_dead
         fall
       end
+      end_y = pos[0]
+      @scoreboard.score_hard_drop(end_y - start_y)
       return true
     end
     false


### PR DESCRIPTION
 closes #54 

# TODO

- [x] Implement leveling system
- [x] Multiply scores by level
- [x] close #57. We can relate the score/level with the speedup.

### Maybe if we finished everything else:
- [ ] ~Implement high score system~ do this in #58 

## Add all these score values
- [x] Soft Drop
- [x] Hard Drop
- [x] Single Line Clear
- [x] Double Line Clear
- [x] Triple Line Clear
- [x] Tetris Line Clear
- [x] Back-to-Back Tetris

### Hard: attempt these in a seperate pull request
- [ ] T-Spin
- [ ] T-Spin Single
- [ ] T-Spin Double
- [ ] T-Spin Triple
- [ ] Back-to-Back T-Spin

### Score Values Table
![Score Values Table](https://user-images.githubusercontent.com/68968548/131267573-0f3e57eb-71a1-4951-9d57-8417822d2de3.png)
